### PR TITLE
Slub always notifies when a Red CI status occurs 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ log-staging:
 
 .PHONY: deploy-staging
 deploy-staging:
-	git push heroku-staging $(BRANCH):master
+	git push heroku-staging $(BRANCH):master --force
 
 .PHONY: log-staging
 od-prod: # Open dashboard production

--- a/src/Slub/Domain/Entity/PR/PR.php
+++ b/src/Slub/Domain/Entity/PR/PR.php
@@ -226,10 +226,6 @@ class PR
 
     public function red(BuildLink $buildLink): void
     {
-        if ($this->CIStatus->isRed()) {
-            return;
-        }
-
         $this->CIStatus = CIStatus::endedWith(BuildResult::red(), $buildLink);
         $this->events[] = CIRed::ForPR($this->PRIdentifier, $buildLink);
     }

--- a/tests/Unit/Domain/Entity/PR/PRTest.php
+++ b/tests/Unit/Domain/Entity/PR/PRTest.php
@@ -194,18 +194,6 @@ class PRTest extends TestCase
     /**
      * @test
      */
-    public function it_does_not_creates_event_if_the_pr_is_already_red()
-    {
-        $pr = $this->redPR();
-
-        $pr->red(BuildLink::none());
-
-        $this->assertEmpty($pr->getEvents());
-    }
-
-    /**
-     * @test
-     */
     public function it_can_become_pending()
     {
         $pr = $this->greenPR();


### PR DESCRIPTION
(even if the PR is already red)