### PR TITLE
Add repository in slack command reponse and fix invalid UserIdentifier when PR is initialized from command

### DIFF
--- a/src/Slub/Infrastructure/Chat/Slack/TR/ProcessTRAsync.php
+++ b/src/Slub/Infrastructure/Chat/Slack/TR/ProcessTRAsync.php
@@ -103,12 +103,13 @@ class ProcessTRAsync
                 'text' => [
                     'type' => 'mrkdwn',
                     'text' => sprintf(
-                        "<%s|%s>\n*<@%s> _(+%s -%s)_*\n\n%s",
+                        "<%s|%s>\n*<@%s> _(+%s -%s)_* [%s]\n\n%s",
                         $PRUrl,
                         $PRInfo->title,
                         $authorIdentifier,
                         $PRInfo->additions,
                         $PRInfo->deletions,
+                        $PRInfo->repositoryIdentifier,
                         sprintf('%s ...', current(explode("\n", wordwrap($PRInfo->description, 100))))
                     ),
                 ],
@@ -142,7 +143,7 @@ class ProcessTRAsync
         $PRToReview->channelIdentifier = $channelIdentifier;
         $PRToReview->workspaceIdentifier = $workspaceIdentifier;
         $PRToReview->messageIdentifier = $messageIdentifier;
-        $PRToReview->authorIdentifier = $authorIdentifier;
+        $PRToReview->authorIdentifier = $PRInfo->authorIdentifier;
         $PRToReview->title = $PRInfo->title;
         $PRToReview->GTMCount = $PRInfo->GTMCount;
         $PRToReview->notGTMCount = $PRInfo->notGTMCount;

--- a/tests/Integration/Infrastructure/Chat/Slack/TR/ProcessTRAsyncTest.php
+++ b/tests/Integration/Infrastructure/Chat/Slack/TR/ProcessTRAsyncTest.php
@@ -83,13 +83,14 @@ class ProcessTRAsyncTest extends WebTestCase
         self::assertEquals('SamirBoulil/slub/153', $PRToReview->PRIdentifier()->stringValue());
         self::assertEquals('published_message_identifier', $PRToReview->messageIdentifiers()[0]->stringValue());
         self::assertEquals('team_123@channel_name', $PRToReview->channelIdentifiers()[0]->stringValue());
-        self::assertEquals(self::USER_ID, $PRToReview->authorIdentifier()->stringValue());
+        self::assertEquals('sam', $PRToReview->authorIdentifier()->stringValue());
     }
 
     private function assertToReviewMessageHasBeenPublished()
     {
         $this->chatClientSpy->assertPublishMessageWithBlocksInChannelContains('team_123@channel_name', 'https://github.com/SamirBoulil/slub/pull/153');
         $this->chatClientSpy->assertPublishMessageWithBlocksInChannelContains('team_123@channel_name', sprintf('<%s>', self::USER_ID));
+        $this->chatClientSpy->assertPublishMessageWithBlocksInChannelContains('team_123@channel_name', '[SamirBoulil/slub]');
     }
 
     private function slashCommandPayload(string $userInput, string $workspaceIdentifier): array


### PR DESCRIPTION
In this PR: 

- I used the authorIdentifier from the github and not anymore the authorIdentifier from slack in order to fix the PR reminder (Like the slack bot do https://github.com/SamirBoulil/slub/blob/master/src/Slub/Infrastructure/Chat/Slack/SlubBot.php#L140) 
![Screenshot from 2021-12-23 08-55-29](https://user-images.githubusercontent.com/7239572/147207471-16f15c7f-e351-4d3a-83df-7fd6cc263ea3.png)

- I added the repositoryIdentifier into the slack command response