### PR TITLE
Escape special html chars in PR title

### DIFF
--- a/src/Slub/Application/PublishReminders/PublishRemindersHandler.php
+++ b/src/Slub/Application/PublishReminders/PublishRemindersHandler.php
@@ -102,9 +102,11 @@ class PublishRemindersHandler
             return sprintf('https://github.com/%s/%s/pull/%s', ...$split);
         };
         $author = ucfirst($PR->authorIdentifier()->stringValue());
-        $title = ChatHelper::elipsisIfTooLong(
-            $PR->title()->stringValue(),
-            80
+        $title = ChatHelper::escapeHtmlChars(
+            ChatHelper::elipsisIfTooLong(
+                $PR->title()->stringValue(),
+                80
+            )
         ); // TODO: Big no no here, Apps -> Infra 😱
         $githubLink = $githubLink($PR);
         $timeInReview = $this->formatDuration($PR);

--- a/src/Slub/Infrastructure/Chat/Common/ChatHelper.php
+++ b/src/Slub/Infrastructure/Chat/Common/ChatHelper.php
@@ -23,9 +23,11 @@ class ChatHelper
             : $firstLine;
     }
 
-    /**
-     *
-     */
+    public static function escapeHtmlChars(string $text): string
+    {
+        return str_replace(['&', '<', '>'], ['&amp;', '&lt;', '&gt;'], $text);
+    }
+
     public static function extractPRIdentifier(string $text): PRIdentifier
     {
         try {

--- a/src/Slub/Infrastructure/Chat/Slack/SlackClient.php
+++ b/src/Slub/Infrastructure/Chat/Slack/SlackClient.php
@@ -190,12 +190,12 @@ SLACK;
                     'text' => sprintf(
                         "*<%s|%s>*\n%s *(+%s -%s)*\n<@%s>\n\n%s",
                         $PRUrl,
-                        ChatHelper::elipsisIfTooLong($title, self::MAX_DESCRIPTION),
+                        ChatHelper::escapeHtmlChars(ChatHelper::elipsisIfTooLong($title, self::MAX_DESCRIPTION)),
                         $repositoryIdentifier,
                         $additions,
                         $deletions,
                         $authorIdentifier,
-                        ChatHelper::elipsisIfTooLong($description, self::MAX_DESCRIPTION)
+                        ChatHelper::escapeHtmlChars(ChatHelper::elipsisIfTooLong($description, self::MAX_DESCRIPTION))
                     ),
                 ],
                 'accessory' => [

--- a/tests/Integration/Infrastructure/Chat/Common/ChatHelperTest.php
+++ b/tests/Integration/Infrastructure/Chat/Common/ChatHelperTest.php
@@ -41,4 +41,21 @@ class ChatHelperTest extends TestCase
         $this->expectException(ImpossibleToParseRepositoryURL::class);
         ChatHelper::extractPRIdentifier('pada yala yada yada');
     }
+
+    public function test_it_escapes_slack_mrkdwn_characters()
+    {
+        $this->assertEquals('&amp;', ChatHelper::escapeHtmlChars('&'));
+        $this->assertEquals('&lt;', ChatHelper::escapeHtmlChars('<'));
+        $this->assertEquals('&gt;', ChatHelper::escapeHtmlChars('>'));
+    }
+
+    public function test_it_escapes_multiple_slack_mrkdwn_characters()
+    {
+        $this->assertEquals('Fix &gt; issue &amp; update &lt;component&gt;', ChatHelper::escapeHtmlChars('Fix > issue & update <component>'));
+    }
+
+    public function test_it_preserves_safe_characters()
+    {
+        $this->assertEquals('Fix PR title with safe characters', ChatHelper::escapeHtmlChars('Fix PR title with safe characters'));
+    }
 }


### PR DESCRIPTION
When a PR title contains some chars, the display in slack is broken:

![Capture d’écran du 2025-07-07 09-32-43](https://github.com/user-attachments/assets/df75c38d-b300-4e0a-8b13-7dd7da754acd)

In this example, the PR title is `PROGX-789: Rules Engine > be able to select Table (All Rows) for table attribute`

According to slack, we must escape 3 special chars:
- https://api.slack.com/reference/surfaces/formatting#escaping


