### PR TITLE
Fix: Prevent duplicate CI failure notifications on branch updates

### DIFF
--- a/src/Slub/Domain/Entity/PR/CIStatus.php
+++ b/src/Slub/Domain/Entity/PR/CIStatus.php
@@ -54,6 +54,16 @@ class CIStatus
 
     public function isRedWithLink(BuildLink $buildLink): bool
     {
-        return $this->buildLink->equals($buildLink);
+        return $this->buildResult->isRed() && $this->buildLink->equals($buildLink);
+    }
+
+    public function isPendingWithLink(BuildLink $buildLink): bool
+    {
+        return $this->buildResult->isPending() && $this->buildLink->equals($buildLink);
+    }
+
+    public function buildLink(): BuildLink
+    {
+        return $this->buildLink;
     }
 }

--- a/src/Slub/Domain/Entity/PR/PR.php
+++ b/src/Slub/Domain/Entity/PR/PR.php
@@ -250,6 +250,10 @@ class PR
         if ($this->CIStatus->isRedWithLink($buildLink)) {
             return;
         }
+        // Don't create event if we're PENDING with this same link (stale webhook from old CI run)
+        if ($this->CIStatus->isPendingWithLink($buildLink)) {
+            return;
+        }
 
         $this->CIStatus = CIStatus::endedWith(BuildResult::red(), $buildLink);
         $this->events[] = CIRed::ForPR($this->PRIdentifier, $buildLink);
@@ -265,9 +269,10 @@ class PR
             return;
         }
 
+        $previousBuildLink = $this->CIStatus->buildLink();
         $this->CIStatus = CIStatus::endedWith(
             BuildResult::pending(),
-            BuildLink::none()
+            $previousBuildLink
         );
         $this->events[] = CIPending::ForPR($this->PRIdentifier);
     }

--- a/tests/Unit/Domain/Entity/PR/PRTest.php
+++ b/tests/Unit/Domain/Entity/PR/PRTest.php
@@ -360,6 +360,69 @@ class PRTest extends TestCase
     /**
      * @test
      */
+    public function it_does_not_creates_event_if_the_pr_is_already_red_with_same_build_link(): void
+    {
+        $buildLink = 'https://build_link';
+        $pr = $this->pendingPR();
+
+        // First time: should create event (PENDING -> RED)
+        $pr->red(BuildLink::fromURL($buildLink));
+        self::assertCount(1, $pr->getEvents());
+        $firstEvent = current($pr->getEvents());
+        self::assertInstanceOf(CIRed::class, $firstEvent);
+
+        // Second time with same link: should NOT create a new event
+        $pr->red(BuildLink::fromURL($buildLink));
+        self::assertCount(1, $pr->getEvents(), 'Should still have only 1 event, not 2');
+    }
+
+    /**
+     * @test
+     */
+    public function it_creates_new_event_if_the_pr_is_red_with_different_build_link(): void
+    {
+        $firstBuildLink = 'https://build_link_1';
+        $secondBuildLink = 'https://build_link_2';
+        $pr = $this->pendingPR();
+
+        // First time: RED with link 1
+        $pr->red(BuildLink::fromURL($firstBuildLink));
+        self::assertCount(1, $pr->getEvents());
+
+        // Second time: RED with different link 2 - should create new event
+        $pr->red(BuildLink::fromURL($secondBuildLink));
+        self::assertCount(2, $pr->getEvents(), 'Should have 2 events for different build links');
+        $events = $pr->getEvents();
+        $secondEvent = end($events);
+        self::assertInstanceOf(CIRed::class, $secondEvent);
+        self::assertEquals($secondBuildLink, $secondEvent->buildLink()->stringValue());
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_create_event_when_stale_webhook_reports_old_failure_after_new_commit(): void
+    {
+        $oldBuildLink = 'https://old_build_link';
+        $pr = $this->pendingPR();
+
+        // Old commit: PR was RED
+        $pr->red(BuildLink::fromURL($oldBuildLink));
+        self::assertCount(1, $pr->getEvents());
+
+        // New commit pushed: PR becomes PENDING
+        $pr->pending();
+        self::assertCount(2, $pr->getEvents());
+
+        // Stale/duplicate webhook reports RED with same old link
+        // This should NOT create a new event (it's the old failure, not a new one)
+        $pr->red(BuildLink::fromURL($oldBuildLink));
+        self::assertCount(2, $pr->getEvents(), 'Should not report old failure as new failure');
+    }
+
+    /**
+     * @test
+     */
     public function it_can_become_pending(): void
     {
         $pr = $this->greenPR();


### PR DESCRIPTION
## Problem

When pushing new commits or updating a branch, users receive duplicate "CI Failed" notifications in Slack for the **old** failure, not the new commit.

**Root Cause:** When a PR transitions to PENDING (new commit pushed), the previous build link was cleared. GitHub then sends a webhook with the old failure status, and the bot treats it as a new failure.

## Solution

**1. Preserve build link when going PENDING** ([PR.php:272-276](src/Slub/Domain/Entity/PR/PR.php#L272-L276))

```php
$previousBuildLink = $this->CIStatus->buildLink();
$this->CIStatus = CIStatus::endedWith(BuildResult::pending(), $previousBuildLink);
```

**2. Detect and ignore stale webhooks (PR.php:254-255)**

```php
if ($this->CIStatus->isPendingWithLink($buildLink)) {
    return; // Stale webhook from old CI run - ignore it
}
```

**3. Added helper methods (CIStatus.php)**

- `isPendingWithLink()` – Check if PENDING with specific build link  
- `buildLink()` – Getter for build link  
- Fixed `isRedWithLink()` – Now checks both status **and** link  

---

### 🧪 Test Coverage

Added 3 tests in `PRTest.php`:

1. **Duplicate RED with same link** (line 363–377)  
2. **Different build links create new events** (line 382–399)  
3. **Stale webhook scenario – the bug fix** (line 404–421)  
---
