### PR TITLE
Accept github shorten url

### DIFF
--- a/src/Slub/Infrastructure/Chat/Common/ChatHelper.php
+++ b/src/Slub/Infrastructure/Chat/Common/ChatHelper.php
@@ -32,7 +32,7 @@ class ChatHelper
     {
         try {
             $text = trim($text);
-            preg_match('#.*https://github.com/(.*)/pull/(\d+).*$#', $text, $matches);
+            preg_match('#.*(?:https://)?github\.com/(.*)/pull/(\d+).*$#', $text, $matches);
             Assert::stringNotEmpty($matches[1]);
             Assert::stringNotEmpty($matches[2]);
             $repositoryIdentifier = $matches[1];

--- a/tests/Integration/Infrastructure/Chat/Common/ChatHelperTest.php
+++ b/tests/Integration/Infrastructure/Chat/Common/ChatHelperTest.php
@@ -34,6 +34,8 @@ class ChatHelperTest extends TestCase
     {
         $this->assertEquals('SamirBoulil/slub/1234', ChatHelper::extractPRIdentifier('https://github.com/SamirBoulil/slub/pull/1234')->stringValue());
         $this->assertEquals('SamirBoulil/slub/1234', ChatHelper::extractPRIdentifier('  https://github.com/SamirBoulil/slub/pull/1234  ')->stringValue());
+        $this->assertEquals('SamirBoulil/slub/1234', ChatHelper::extractPRIdentifier('github.com/SamirBoulil/slub/pull/1234')->stringValue());
+        $this->assertEquals('SamirBoulil/slub/1234', ChatHelper::extractPRIdentifier('  github.com/SamirBoulil/slub/pull/1234  ')->stringValue());
     }
 
     public function test_it_throws_if_the_pr_identifier_cannot_be_extracted()

--- a/tests/Integration/Infrastructure/Chat/Slack/TR/ProcessTRAsyncTest.php
+++ b/tests/Integration/Infrastructure/Chat/Slack/TR/ProcessTRAsyncTest.php
@@ -31,16 +31,26 @@ class ProcessTRAsyncTest extends WebTestCase
     public function test_it_handles_pr_to_review_submission(): void
     {
         $client = self::getClient();
-        $client->request('POST', '/chat/slack/tr', $this->PRToReviewSubmission());
+        $client->request('POST', '/chat/slack/tr', $this->PRToReviewSubmission('https://github.com/SamirBoulil/slub/pull/153'));
         $this->assertEquals(200, $client->getResponse()->getStatusCode());
         $this->assertPRHasBeenPutToReview();
         // TODO: For some reason the chat client spy is empty whenever we return from the request.
         // $this->assertToReviewMessageHasBeenPublished();
     }
 
-    private function PRToReviewSubmission(): array
+    public function test_it_handles_pr_to_review_submission_with_shorten_url(): void
     {
-        return $this->slashCommandPayload('blabla https://github.com/SamirBoulil/slub/pull/153 blabla', 'team_123');
+        $client = self::getClient();
+        $client->request('POST', '/chat/slack/tr', $this->PRToReviewSubmission('github.com/SamirBoulil/slub/pull/153'));
+        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertPRHasBeenPutToReview();
+        // TODO: For some reason the chat client spy is empty whenever we return from the request.
+        // $this->assertToReviewMessageHasBeenPublished();
+    }
+
+    private function PRToReviewSubmission(string $url): array
+    {
+        return $this->slashCommandPayload('blabla '.$url.' blabla', 'team_123');
     }
 
     private function assertPRHasBeenPutToReview()


### PR DESCRIPTION
When copy an url in slack, it can shorten the url. Ex: `https://github.com/...` is updated in `github.com/...` automatically (ctrl-z can fix the issue but it's not known by everyone)
This behavior is seen on linux with the client, not on Mac for now.

`/tr` command doesn't accept  these urls:

```
/tr github.com/...
Sorry, I was not able to parse the pull request URL, can you check it and try again ?
```

Now yee accepts these urls